### PR TITLE
Make recorder's `takeFullSnapshot` function public

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -179,7 +179,7 @@ export type SamplingStrategy = Partial<{
    */
   input: 'all' | 'last';
   /**
-   * throttle threshold from tramission to the snapshot 
+   * throttle threshold from tramission to the snapshot
    */
   mouseTransmitThreshold: number
 }>;
@@ -201,7 +201,7 @@ export type recordOptions<T> = {
   sampling?: SamplingStrategy;
   recordCanvas?: boolean;
   collectFonts?: boolean;
-  // departed, please use sampling options
+  // deprecated, please use sampling options
   mousemoveWait?: number;
   recordLog?: boolean | LogRecordOptions;
 };
@@ -507,7 +507,7 @@ export type playerConfig = {
       };
   unpackFn?: UnpackFn;
   logConfig: LogReplayConfig;
-  customCursor: string
+  customCursor?: string
 };
 
 export type LogReplayConfig = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,8 +1,8 @@
-import record from './record';
+import record, { Recorder } from './record';
 import { Replayer } from './replay';
 import { mirror } from './utils';
 import * as utils from './utils';
 export { EventType, IncrementalSource, MouseInteractions, ReplayerEvents, } from './types';
 declare const addCustomEvent: <T>(tag: string, payload: T) => void;
 declare const freezePage: () => void;
-export { record, addCustomEvent, freezePage, Replayer, mirror, utils };
+export { record, Recorder, addCustomEvent, freezePage, Replayer, mirror, utils };

--- a/typings/record/index.d.ts
+++ b/typings/record/index.d.ts
@@ -1,4 +1,13 @@
 import { eventWithTime, recordOptions, listenerHandler } from '../types';
+
+export declare class Recorder<T = eventWithTime> {
+    constructor (
+        onEmit: (e: T, isCheckout?: boolean) => void,
+        options?: Exclude<recordOptions<T>, 'emit'>,
+    );
+    start(): listenerHandler | undefined;
+    takeFullSnapshot(isCheckout?: boolean): void;
+}
 declare function record<T = eventWithTime>(options?: recordOptions<T>): listenerHandler | undefined;
 declare namespace record {
     var addCustomEvent: <T>(tag: string, payload: T) => void;


### PR DESCRIPTION
# Ticket
https://www.notion.so/gitduck/Browser-sharing-If-someone-joins-a-call-after-someone-shared-its-browser-will-not-properly-see-it-4c9cef01859b41d28a068911d8aeae68

## Summary
Turn the private function `takeFullSnapshot` public so we can take snapshots when new-peers arrive.