### PR TITLE
Drawing and moving custom cursors

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -293,7 +293,7 @@ The replayer accepts options as its constructor's second parameter, and it has t
 | mouseTail           | true          | whether to show mouse tail during replay. Set to false to disable mouse tail. A complete config can be found in this [type](https://github.com/rrweb-io/rrweb/blob/9488deb6d54a5f04350c063d942da5e96ab74075/src/types.ts#L407) |
 | unpackFn            | -             | refer to the [storage optimization recipe](./docs/recipes/optimize-storage.md)                                                                                                                                                 |
 | logConfig           | -             | configuration of console output playback, refer to the [console recipe](./docs/recipes/console.md)                                                                                                                             |
-| customCursor           | -             | overrides the default cursor, expects a CSS base64 string                                                                                                                            |
+| customCursor           | -             | overrides the default cursor, expects an HTMLDivElement                                                                                                                         |
 
 #### Use rrweb-player
 

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1511,7 +1511,7 @@ export class Replayer {
     console.log(REPLAY_CONSOLE_PREFIX, ...args);
   }
 
-  private drawCustomCursor(customCursor: HTMLDivElement, posX:number, posY: number, isNewCursor: boolean) {
+  public drawCustomCursor(customCursor: HTMLDivElement, posX:number, posY: number, isNewCursor: boolean) {
     if (isNewCursor) {
       this.wrapper.prepend(customCursor)
     }

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -375,10 +375,11 @@ export class Replayer {
     this.wrapper.classList.add('replayer-wrapper');
     this.config.root!.appendChild(this.wrapper);
 
-    this.mouse = document.createElement('div');
-    this.mouse.classList.add('replayer-mouse');
     if (this.config.customCursor) {
-      this.mouse.style.backgroundImage = this.config.customCursor;
+      this.mouse = this.config.customCursor
+    } else {
+      this.mouse = document.createElement('div');
+      this.mouse.classList.add('replayer-mouse');
     }
     
     this.wrapper.appendChild(this.mouse);

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1454,4 +1454,12 @@ export class Replayer {
     // tslint:disable-next-line: no-console
     console.log(REPLAY_CONSOLE_PREFIX, ...args);
   }
+
+  private drawCustomCursor(customCursor: HTMLDivElement, posX:number, posY: number, isNewCursor: boolean) {
+    if (isNewCursor) {
+      this.wrapper.prepend(customCursor)
+    }
+    customCursor.style.left = `${posX}px`
+    customCursor.style.top = `${posY}px`
+  }
 }

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1340,8 +1340,7 @@ export class Replayer {
   }
 
   private moveAndHover(d: incrementalData, x: number, y: number, id: number) {
-    if(this.currentFitSize !== null) 
-    {
+    if (this.currentFitSize !== null) {
       x *= this.offsetFactorFit
       y = ( y * this.offsetFactorFit ) + this.offsetMarginFit
     }
@@ -1512,6 +1511,11 @@ export class Replayer {
   }
 
   public drawCustomCursor(customCursor: HTMLDivElement, posX:number, posY: number, isNewCursor: boolean) {
+    // TODO: abstract to function applyScaling
+    if( this.currentFitSize !== null) {
+      posX *= this.offsetFactorFit
+      posY = ( posY * this.offsetFactorFit ) + this.offsetMarginFit
+    }
     if (isNewCursor) {
       this.wrapper.prepend(customCursor)
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -499,7 +499,7 @@ export type playerConfig = {
       };
   unpackFn?: UnpackFn;
   logConfig: LogReplayConfig;
-  customCursor: string
+  customCursor: HTMLDivElement
 };
 
 export type LogReplayConfig = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -499,7 +499,7 @@ export type playerConfig = {
       };
   unpackFn?: UnpackFn;
   logConfig: LogReplayConfig;
-  customCursor: HTMLDivElement
+  customCursor?: HTMLDivElement
 };
 
 export type LogReplayConfig = {

--- a/typings/replay/index.d.ts
+++ b/typings/replay/index.d.ts
@@ -59,5 +59,5 @@ export declare class Replayer {
     private debugNodeNotFound;
     private warn;
     private debug;
-    drawCustomCursor
+    drawCustomCursor(customCursor: HTMLDivElement, posX:number, posY: number, isNewCursor: boolean): void
 }

--- a/typings/replay/index.d.ts
+++ b/typings/replay/index.d.ts
@@ -57,4 +57,5 @@ export declare class Replayer {
     private debugNodeNotFound;
     private warn;
     private debug;
+    drawCustomCursor
 }

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -360,7 +360,7 @@ export declare type playerConfig = {
     };
     unpackFn?: UnpackFn;
     logConfig: LogReplayConfig;
-    customCursor: string;
+    customCursor: HTMLDivElement;
 };
 export declare type LogReplayConfig = {
     level?: Array<LogLevel> | undefined;

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -360,7 +360,7 @@ export declare type playerConfig = {
     };
     unpackFn?: UnpackFn;
     logConfig: LogReplayConfig;
-    customCursor: HTMLDivElement;
+    customCursor?: HTMLDivElement;
 };
 export declare type LogReplayConfig = {
     level?: Array<LogLevel> | undefined;


### PR DESCRIPTION
1. Assigns drawing and moving mouse cursors to rrweb Replayer by creating a new public method
2. Considers changes introduced in #6. This is actually currently duplicating the code that is implemented [here](https://github.com/gitduckhq/rrweb/pull/6/files#diff-4a72ff0b3cdf9920ea38bca8f69eedbfe52c99904a0036f3fc1cd7c1e0248a37R1342). I want to refactor this later into a pure function